### PR TITLE
feat: 🎸 Adds Escape event listener to put piece back

### DIFF
--- a/partridge.js
+++ b/partridge.js
@@ -64,7 +64,7 @@ function psquares_init(id, config) {
     document.addEventListener(
         "keydown",
         (event) => {
-          const keyName = event.key;
+          var keyName = event.key;
 
           if (keyName === "Escape") {
             psquares_unset_piece();

--- a/partridge.js
+++ b/partridge.js
@@ -61,6 +61,18 @@ function psquares_init(id, config) {
             psquares_place_piece(data[i][1]+(data[i][0]-1)/2, data[i][2]+(data[i][0]-1)/2);
         }
     }
+    document.addEventListener(
+        "keydown",
+        (event) => {
+          const keyName = event.key;
+
+          if (keyName === "Escape") {
+            psquares_unset_piece();
+            return;
+          }
+        },
+        false,
+      );
 
 }
 


### PR DESCRIPTION
Thanks for making this.  I watched Matt Parker's video and found your page. I enjoyed playing around with this puzzle, but it was really bugging me me that I couldn't put pieces back, to make more room on the board for moving pieces around.  So I wanted to allow putting a piece back with Escape, and figured I would make the PR in case this is something you want to share.

It looks like you built the `psquares_unset_piece()` function to do this already which made my job much easier here, and it seems to work well.  Was it an intentional decision to not have this function?  If so, feel free not to accept the PR.

Thanks.